### PR TITLE
whichwrap-independent Insert

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1507,7 +1507,6 @@ function s:PlaceDelimitersAndInsBetween()
     else
         execute ':normal! ' . insOrApp . left
     endif
-    silent! normal! l
 
     "if needed convert spaces back to tabs and adjust the cursors col
     "accordingly
@@ -1520,7 +1519,7 @@ function s:PlaceDelimitersAndInsBetween()
     if isDelimOnEOL && lenRight ==# 0
         startinsert!
     else
-        startinsert
+        call feedkeys('a', 'ni')
     endif
 endfunction
 


### PR DESCRIPTION
If `set whichwrap+=l`, `normal! l` may move the cursor to the next line, which breaks  `NERDCommenterInsert`. Instead, we can merge `normal! l` and `startinsert` into `feedkeys('a', 'ni')`. Note that [`normal! a` doesn't work](https://stackoverflow.com/q/11587124).

Another solution is to reset `whichwrap` to default before running `normal! l` but I think feedkeys is simpler.