### PR TITLE
tentative fix of issue #425

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -703,7 +703,7 @@ function s:CommentBlock(top, bottom, lSide, rSide, forceNested )
     "alternative delimiters (if THEY are) as the comment will be better and more
     "accurate with multipart delimiters
     let switchedDelims = 0
-    if !s:Multipart() && g:NERDAllowAnyVisualDelims && s:AltMultipart()
+    if !s:Multipart() && !g:NERDAllowAnyVisualDelims && s:AltMultipart()
         let switchedDelims = 1
         call s:SwitchToAlternativeDelimiters(0)
     endif


### PR DESCRIPTION
in the file ```plugin/NERD_commenter.vim``` inside the function s:CommentBlock, the following if...endif statement
```vim
 if !s:Multipart() && g:NERDAllowAnyVisualDelims && s:AltMultipart()
        let switchedDelims = 1
        call s:SwitchToAlternativeDelimiters(0)
    endif
```
should be replaced with

```vim
 if !s:Multipart() && !g:NERDAllowAnyVisualDelims && s:AltMultipart()
        let switchedDelims = 1
        call s:SwitchToAlternativeDelimiters(0)
    endif
```
since the switch to alternative delimiters 
should occur only if g:NERDAllowAnyVisualDelims = 0