### PR TITLE
Add support for the `nix` language.

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -292,6 +292,7 @@ let s:delimiterMap = {
     \ 'newlisp': { 'left': ';' },
     \ 'nginx': { 'left': '#' },
     \ 'nimrod': { 'left': '#' },
+    \ 'nix': { 'left': '#' },
     \ 'nroff': { 'left': '\"' },
     \ 'nsis': { 'left': '#' },
     \ 'ntp': { 'left': '#' },


### PR DESCRIPTION
This PR adds support for the nix language, it just uses a single `#` on the left to comment out a line so I've added this to the `delimiterMap`.
The nix language is used by [nixpkgs](https://github.com/NixOS/nixpkgs), [NixOS](https://nixos.org/) and some other Nix-related projects.

Thank you for the plugin! Just trying to get this in so future nix programmers don't have to set `NERDCustomDelimiters`.