### PR TITLE
NERDCommenterInvert will not work correctly if there isn't an extra space (Haskell)

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -197,7 +197,7 @@ let s:delimiterMap = {
     \ 'h': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'haml': { 'left': '-#', 'leftAlt': '/' },
     \ 'handlebars': { 'left': '{{!-- ', 'right': ' --}}' },
-    \ 'haskell': { 'left': '--', 'nested': 0, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
+    \ 'haskell': { 'left': '-- ', 'nested': 0, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
     \ 'haxe': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hb': { 'left': '#' },
     \ 'hbs': { 'left': '{{!-- ', 'right': ' --}}' },


### PR DESCRIPTION
see this image:
![image](https://user-images.githubusercontent.com/24462335/100835452-a9b72900-343b-11eb-9e0e-18ff5933e510.png)
after:
![image](https://user-images.githubusercontent.com/24462335/100835539-d2d7b980-343b-11eb-9780-1b19cb523455.png)
