### PR TITLE
fix: can't uncomment in sexy mode with NERDCompactSexyComs=1 for lua

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -2152,7 +2152,7 @@ endfunction
 " Function: s:Esc(str)
 " Escapes all the tricky chars in the given string
 function s:Esc(str)
-    let charsToEsc = '*/\."&$+'
+    let charsToEsc = '*/\."&$+[]'
     return escape(a:str, charsToEsc)
 endfunction
 


### PR DESCRIPTION
reproduce issue:
1. open lua file;
2. run ex `let g:NERDCompactSexyComs = 1`;
3. enter visual mode and select multiple lines;
4. `<leader>cs`;
5. `<leader>cu`;

solve this issue by escaping `[` and `]`.