### PR TITLE
Update rego comment to #

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -353,7 +353,7 @@ let s:delimiterMap = {
     \ 'rc': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'rebol': { 'left': ';' },
     \ 'registry': { 'left': ';' },
-    \ 'rego': { 'left': ';' },
+    \ 'rego': { 'left': '#' },
     \ 'remind': { 'left': '#' },
     \ 'renpy': { 'left': '# ' },
     \ 'resolv': { 'left': '#' },


### PR DESCRIPTION
Update to the [Open Policy Agent ](https://www.openpolicyagent.org) comment character. Based on the [policy-language](https://www.openpolicyagent.org/docs/latest/policy-language/), a comment begins with `#`.


![image](https://user-images.githubusercontent.com/56614456/106334154-ee462180-623e-11eb-9bfb-a5094b973f44.png)
