### PR TITLE
Add neo4j cypher filetype

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -121,6 +121,7 @@ let s:delimiterMap = {
     \ 'cucumber': { 'left': '#' },
     \ 'cuda': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'cvs': { 'left': 'CVS:' },
+    \ 'cypher': { 'left': '//' },
     \ 'cython': { 'left': '# ', 'leftAlt': '#' },
     \ 'd': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'dakota': { 'left': '#' },


### PR DESCRIPTION
Let nerdcommenter properly comment cypher files.

* [extension recommendation](https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-general-recommendations)
* [comments syntax](https://neo4j.com/docs/cypher-manual/current/syntax/comments/)