### PR TITLE
Fix multibyte character bug in block comment

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -750,7 +750,9 @@ function s:CommentBlock(top, bottom, lSide, rSide, forceNested )
 
                     if s:Multipart()
                         "stick the right delimiter down
-                        let theLine = strpart(theLine, 0, rSide+strlen(leftSpaced)) . rightSpaced . strpart(theLine, rSide+strlen(leftSpaced))
+                        "byte idx of the char next to the last char = (byte idx of last char + 1) + (last char byte len) - 1
+                        let rIndex = (rSide+strlen(leftSpaced)) + strlen(strcharpart(strpart(theLine, rSide+strlen(leftSpaced)-1), 0, 1)) - 1
+                        let theLine = strpart(theLine, 0, rIndex) . rightSpaced . strpart(theLine, rIndex)
 
                         let firstLeftDelim = s:FindDelimiterIndex(s:Left(), theLine)
                         let lastRightDelim = s:LastIndexOfDelim(s:Right(), theLine)


### PR DESCRIPTION
<Plug>NERDCommenterComment using block comment on visual block whose
last char is unicode breaks up the unicode char. Example:

    a가 → /* a<ea> */<b0><80>

To fix this, add the character's byte length to the index used for
chopping the right part of the text block to be commented.