### PR TITLE
Simplify and fix NERDCommenterInsert

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1429,12 +1429,13 @@ function! s:PlaceDelimitersAndInsBetween() abort
     "    Otherwise, use 'i'.
     let insert = col('.') > strlen(getline('.')) ? 'a' : 'i'
     " 2. Insert comment delimiters.
-    " 3. Move the cursor to the left of the closing delimiter.
+    " 3. Move the cursor to the left of the closing delimiter, without
+    "    breaking undo sequence.
     " 4. Enter insert normal mode again without changing the cursor position.
     "    This ensures that returning to the insert mode after finishing the
     "    script execution does not move the cursor.
-    "                 ( 1  )   (    2     )   (                3               )   (      4     )
-    execute 'normal!' insert . left . right . repeat("\<Left>", strchars(right)) . "\<C-\>\<C-O>"
+    "                 ( 1  )   (    2     )   (                   3                   )   (      4     )
+    execute 'normal!' insert . left . right . repeat("\<C-G>U\<Left>", strchars(right)) . "\<C-\>\<C-O>"
 endfunction
 
 " Function: s:RemoveDelimiters(left, right, line)

--- a/plugin/nerdcommenter.vim
+++ b/plugin/nerdcommenter.vim
@@ -125,7 +125,7 @@ function! NERDCommentIsCharCommented(line, col)
     return nerdcommenter#IsCharCommented(a:line, a:col)
 endfunction
 
-inoremap <silent> <Plug>NERDCommenterInsert <Space><BS><Esc>:call nerdcommenter#Comment('i', "insert")<CR>
+inoremap <silent> <Plug>NERDCommenterInsert <C-\><C-O>:call nerdcommenter#Comment('i', "Insert")<CR>
 
 " switch to/from alternative delimiters (does not use wrapper function)
 nnoremap <Plug>NERDCommenterAltDelims :call nerdcommenter#SwitchToAlternativeDelimiters(1)<CR>


### PR DESCRIPTION
* Simplify comment delimiter insertion.
* Remove the code that unnecessarily touches the leading spaces/tabs.
* Fix a bug in which `<Plug>NERDCommenterInsert` inserts the comment
  delimiters in a wrong position when `col('.')==1`.
  Example: `1|234` (cursor at `|`) → `/* */1234`.
* NOTE: Should avoid `feedkey(.., 'ni')` for inserting comment
  delimiters to ensure that `NERDCommenter_after` is called after
  inserting the delimiters. `feedkey` only adds the input to the queue,
  which will be processed after exiting the script context. On the other
  hand, `:normal` and `feedkey(.., 'x')` are eagerly processed.