### PR TITLE
Add SetUp call in IsLineCommented function definition

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1153,6 +1153,7 @@ endfunction
 "   -lineNo:    the line number of the line to check
 " Return: Number, 1 if the line is a comment, 0 else
 function! nerdcommenter#IsLineCommented(lineNo) abort
+    call nerdcommenter#SetUp()
     let theLine = getline(a:lineNo)
     return s:IsInSexyComment(a:lineNo) || s:IsCommentedFromStartOfLine(s:Left(), theLine) || s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
 endfunction


### PR DESCRIPTION
After I add a custom keymap likes following segment
```
nmap <silent> <expr> gc nerdcommenter#IsLineCommented(line(".")) ?
 \ "\:call nerdcommenter#Comment(1, 'uncomment')<CR>"
 \ : "\:call nerdcommenter#Comment(1, 'alignBoth')<CR>"
```

Call the map in a buffer that without any nerdCommenter's comment function been invoked before, vim will complain "E121: Undefined variable: b:NERDCommenterDelims".

Add `nerdcommenter#SetUp` invoke will make vim stop complaining.