### PR TITLE
Add support for Starkware cairo

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -50,6 +50,7 @@ let s:delimiterMap = {
     \ 'btm': { 'left': '::' },
     \ 'c': { 'left': '/*', 'right': '*/', 'leftAlt': '//' },
     \ 'cabal': { 'left': '--' },
+    \ 'cairo': { 'left': '#' },
     \ 'calibre': { 'left': '//' },
     \ 'caos': { 'left': '*' },
     \ 'catalog': { 'left': '--', 'right': '--' },


### PR DESCRIPTION
Adding support for cairo language by Starkware: https://www.cairo-lang.org/

There isn't an official ft plugin for it yet, but this is what's being used by the community as of now with the ft being defined as `cairo`
https://github.com/starkware-libs/cairo-lang/tree/master/src/starkware/cairo/lang/ide/vim

