### PR TITLE
fix issues with placeholders not being replaced by real comment strings when uncommenting

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1766,6 +1766,8 @@ function! s:UncommentLineNormal(line) abort
     endif
 
 
+    let indxLeft = s:FindDelimiterIndex(s:Left(), line)
+    let indxLeftAlt = s:FindDelimiterIndex(s:Left({'alt': 1}), line)
     let indxLeftPlace = s:FindDelimiterIndex(g:NERDLPlace, line)
     let indxRightPlace = s:FindDelimiterIndex(g:NERDRPlace, line)
 


### PR DESCRIPTION
Recompute `indxLeft` and `indxLeftAlt` after line has changed.

Further on, the code checks if `indxLeftPlace < indxLeft` to determine whether there is a placeholder,
however the `indxLeft` is wrong as it is first computed before the line is uncommented but `indxLeftPlace` is computed after uncommenting.

Related to this PR that was never merged: https://github.com/preservim/nerdcommenter/pull/226
Related issue: https://github.com/preservim/nerdcommenter/issues/68