### PR TITLE
feat(dosbatch): change `dosbatch` delimiters

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -91,7 +91,7 @@ let s:delimiterMap = {
     \ 'dns': { 'left': ';' },
     \ 'docbk': { 'left': '<!--', 'right': '-->' },
     \ 'dockerfile': { 'left': '#' },
-    \ 'dosbatch': { 'left': 'REM ', 'leftAlt': '::' },
+    \ 'dosbatch': { 'left': 'REM ', 'nested': 1, 'leftAlt': 'REM ', 'nestedAlt': 1 },
     \ 'dosini': { 'left': ';' },
     \ 'dot': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'dracula': { 'left': ';' },


### PR DESCRIPTION
Change `left` and `leftAlt` delimiters to nestable `REM ` (extra space character is required) for security and compatibility reasons. Here is two (the shortest) of the many justifications:

- [tldr](https://stackoverflow.com/a/12407934)
- [generalized](https://stackoverflow.com/a/12408045)