### PR TITLE
Fix bug for unable to uncomment indented comments in vim files

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -2534,9 +2534,8 @@ function! s:IsDelimValid(delimiter, delIndx, line) abort
             return 0
         endif
 
-        "if the delimiter is on the very first char of the line or is the
-        "first non-tab/space char on the line then it is a valid comment delimiter
-        if a:delIndx ==# 0 || a:line =~# "^\s\\{" . a:delIndx . "\\}\".*$"
+        # If delimiter is the first non-whitespace character it is valid
+        if a:line =~ '^\s*"'
             return 1
         endif
 

--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -2535,7 +2535,7 @@ function! s:IsDelimValid(delimiter, delIndx, line) abort
         endif
 
         # If delimiter is the first non-whitespace character it is valid
-        if a:line =~ '^\s*"'
+        if a:line =~# '^\s*"'
             return 1
         endif
 


### PR DESCRIPTION
Closes #491

The fix is quite transparent - just use a regular expression to find the first comment character.