### PR TITLE
Update starkware cairo comments to latest syntax

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -50,7 +50,7 @@ let s:delimiterMap = {
     \ 'btm': { 'left': '::' },
     \ 'c': { 'left': '/*', 'right': '*/', 'leftAlt': '//' },
     \ 'cabal': { 'left': '--' },
-    \ 'cairo': { 'left': '#' },
+    \ 'cairo': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'calibre': { 'left': '//' },
     \ 'caos': { 'left': '*' },
     \ 'catalog': { 'left': '--', 'right': '--' },


### PR DESCRIPTION
Starkware has released updates to the Cairo language where they replaced the `#` comments with `//` and in the upcoming 1.0 version, they'll support `//` as well as `/* */` equivalent to Rust. 

Cairo 1.0 repository for reference: https://github.com/starkware-libs/cairo