### PR TITLE
Correct use of b:NERDCommenterFirstInit

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -491,7 +491,7 @@ function! nerdcommenter#SetUp() abort
             endif
         endfor
         " if g:NERD_<filetype>_alt_style is defined, use the alternate style
-        let b:NERDCommenterFirstInit = getbufvar(1,'NERDCommenterFirstInit')
+        let b:NERDCommenterFirstInit = getbufvar(bufnr(),'NERDCommenterFirstInit')
         if exists('g:NERDAltDelims_'.filetype) && eval('g:NERDAltDelims_'.filetype) && !b:NERDCommenterFirstInit
             let b:NERDCommenterFirstInit = 1
             call nerdcommenter#SwitchToAlternativeDelimiters(0)


### PR DESCRIPTION
fix #518

The code set the variable `b:NERDCommenterFirstInit` on the current buffer, but access the variable using buffer number 1 - this should be incorrect. Changed to `bufnr()` instead.