### PR TITLE
Provide argument for bufnr

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -492,7 +492,7 @@ function! nerdcommenter#SetUp() abort
             endif
         endfor
         " if g:NERD_<filetype>_alt_style is defined, use the alternate style
-        let b:NERDCommenterFirstInit = getbufvar(bufnr(),'NERDCommenterFirstInit')
+        let b:NERDCommenterFirstInit = getbufvar(bufnr('%'),'NERDCommenterFirstInit')
         if exists('g:NERDAltDelims_'.filetype) && eval('g:NERDAltDelims_'.filetype) && !b:NERDCommenterFirstInit
             let b:NERDCommenterFirstInit = 1
             call nerdcommenter#SwitchToAlternativeDelimiters(0)


### PR DESCRIPTION
There's an error in vim 8.0:

```
E119: Not enough arguments for function: bufnr
E116: Invalid arguments for function getbufvar(bufnr(),'NERDCommenterFirstInit')
E15: Invalid expression: getbufvar(bufnr(),'NERDCommenterFirstInit')
```

In that version, `bufnr` requires an argument, so pass `"%"`, which means current buffer.