### PR TITLE
Add new delimiter for HCL files

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -161,6 +161,7 @@ let s:delimiterMap = {
     \ 'haxe': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hb': { 'left': '#' },
     \ 'hbs': { 'left': '{{!-- ', 'right': ' --}}' },
+    \ 'hcl': { 'left': '#', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hercules': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hive': { 'left': '-- ' },
     \ 'hocon': { 'left': '//', 'leftAlt': '#' },


### PR DESCRIPTION
Adds support for raw HCL files, docs [here](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/syntax#comments).