### PR TITLE
Add delimiters for Alloy files

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -15,6 +15,7 @@ let s:delimiterMap = {
     \ 'ada': { 'left': '--', 'leftAlt': '--  ' },
     \ 'ahdl': { 'left': '--' },
     \ 'ahk': { 'left': ';', 'leftAlt': '/*', 'rightAlt': '*/' },
+    \ 'alloy': { 'left': '/*', 'right': '*/', 'leftAlt': '//' },
     \ 'amiga': { 'left': ';' },
     \ 'aml': { 'left': '/*' },
     \ 'ampl': { 'left': '#' },


### PR DESCRIPTION
see: https://alloytools.org/tutorials/online/sidenote-format-comments.html