### PR TITLE
toggle comment depends on previous line

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1019,7 +1019,8 @@ function! s:CommentLinesToggle(forceNested, firstLine, lastLine) abort
     let currentLine = a:firstLine
 
     let align = g:NERDDefaultAlign
-    let leftAlignIndx = align ==# 'start' ? 0 : s:LeftMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
+    let lookBehind = align ==# 'previous' && currentLine != 1 && s:IsCommentedFromStartOfLine(s:Left(), getline(currentLine - 1))
+    let leftAlignIndx = align ==# 'start' ? 0 : s:LeftMostIndx(a:forceNested, 0, a:firstLine - lookBehind, a:lastLine)
     let rightAlignIndx = s:RightMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
     let rightAlignIndx = rightAlignIndx + strlen(s:Left({'space': 1}))
 
@@ -1037,7 +1038,7 @@ function! s:CommentLinesToggle(forceNested, firstLine, lastLine) abort
                 let theLine = s:SwapOuterMultiPartDelimsForPlaceHolders(theLine)
             endif
 
-            if align ==# 'left' || align ==# 'start' || align ==# 'both'
+            if align ==# 'left' || align ==# 'start' || align ==# 'both' || align ==# 'previous'
                 let theLine = s:AddLeftDelimAligned(s:Left({'space': 1}), theLine, leftAlignIndx)
             else
                 let theLine = s:AddLeftDelim(s:Left({'space': 1}), theLine)

--- a/doc/nerdcommenter.txt
+++ b/doc/nerdcommenter.txt
@@ -503,8 +503,8 @@ change the filetype back: >
                                       style sexy comments.
 
 |'NERDDefaultAlign'|                  Specifies the default alignment to use,
-                                      one of 'none', 'left', 'start', or
-                                      'both'.
+                                      one of 'none', 'left', 'start', 'both'
+                                      or 'previous'.
 
 |'NERDToggleCheckAllLines'|           Enable NERDCommenterToggle to check
                                       all selected lines is commented or not.
@@ -784,7 +784,7 @@ deleted when uncommenting a line.
 
 ------------------------------------------------------------------------------
                                                              *'NERDDefaultAlign'*
-Values: 'none', 'left', 'start', 'both'
+Values: 'none', 'left', 'start', 'both', 'previous'.
 Default 'none'.
 
 Specifies the default alignment to use when inserting comments.


### PR DESCRIPTION
i'm using pycharm/vscode-like mapping: `nmap <C-/> <plug>NERDCommenterToggle <bar> j`