### PR TITLE
Add delimiter for pamenv

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -280,6 +280,7 @@ let s:delimiterMap = {
     \ 'ox': { 'left': '//' },
     \ 'paludis-use-conf': { 'left': '#' },
     \ 'pandoc': { 'left': '<!--', 'right': '-->' },
+    \ 'pamenv': { 'left': '#' },
     \ 'pascal': { 'left': '{', 'right': '}', 'leftAlt': '(*', 'rightAlt': '*)' },
     \ 'patran': { 'left': '$', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'pcap': { 'left': '#' },


### PR DESCRIPTION
> The "#" character at start of line (no space at front) can be used to mark this line as a comment line.
https://man7.org/linux/man-pages/man5/pam_env.conf.5.html