### PR TITLE
Fix alternative delimiter usage in alternate buffers

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -484,7 +484,7 @@ function! nerdcommenter#SetUp() abort
     let b:NERDSexyComMarker = ''
 
     if has_key(s:delimiterMap, filetype)
-        let b:NERDCommenterDelims = s:delimiterMap[filetype]
+        let b:NERDCommenterDelims = copy(s:delimiterMap[filetype])
         for i in ['left', 'leftAlt', 'right', 'rightAlt']
             if !has_key(b:NERDCommenterDelims, i)
                 let b:NERDCommenterDelims[i] = ''


### PR DESCRIPTION
Copy the configuration for a file rather than capture by reference.

Due to the logic in the alternative delimiter configurator, which swaps the delimiters when called, every second buffer the script is used swaps the delimiter order in the original config. This leads to incorrect delimiters being used in every second buffer.

This change makes a copy for each buffer so swapping the order will not affect the next loaded buffer.