### PR TITLE
Add delimiter for aptconf

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -24,6 +24,7 @@ let s:delimiterMap = {
     \ 'apachestyle': { 'left': '#' },
     \ 'apdl': { 'left': '!' },
     \ 'applescript': { 'left': '--', 'leftAlt': '(*', 'rightAlt': '*)' },
+    \ 'aptconf': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'armasm': { 'left': ';' },
     \ 'asciidoc': { 'left': '//' },
     \ 'asm': { 'left': ';', 'leftAlt': '#' },


### PR DESCRIPTION
> Lines starting with // are treated as comments (ignored), as well as all text between /* and */, just like C/C++ comments.
> https://manpages.debian.org/stretch/apt/apt.conf.5.en.html

Used for config `/etc/apt/apt.conf` and configs in `/etc/apt/apt.conf.d/`.