### PR TITLE
fix: correct logic for switching alt delimiters

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -486,7 +486,7 @@ function! nerdcommenter#SetUp() abort
     let b:NERDSexyComMarker = ''
 
     if has_key(s:delimiterMap, filetype)
-        let b:NERDCommenterDelims = copy(s:delimiterMap[filetype])
+        let b:NERDCommenterDelims = s:delimiterMap[filetype]
         for i in ['left', 'leftAlt', 'right', 'rightAlt']
             if !has_key(b:NERDCommenterDelims, i)
                 let b:NERDCommenterDelims[i] = ''


### PR DESCRIPTION
- Fixed a problem where toggling delimiters was not working due to copy statement.
- Confirmed that toggling works correctly across different buffers.