### PR TITLE
Add ability to specify register when yanking

### DIFF
--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1291,11 +1291,11 @@ function! nerdcommenter#Comment(mode, type) range abort
 
     elseif a:type ==? 'Yank'
         if isVisual
-            normal! gvy
+            execute 'normal! gv"'. v:register . 'y'
         elseif countWasGiven
-            execute firstLine .','. lastLine .'yank'
+            execute firstLine .','. lastLine .'yank '. v:register
         else
-            normal! yy
+            execute 'normal! "'. v:register .'yy'
         endif
         execute firstLine .','. lastLine .'call nerdcommenter#Comment("'. a:mode .'", "Comment")'
     endif

--- a/autoload/nerdcommenter.vim
+++ b/autoload/nerdcommenter.vim
@@ -1290,12 +1290,13 @@ function! nerdcommenter#Comment(mode, type) range abort
         call s:UncommentLines(firstLine, lastLine)
 
     elseif a:type ==? 'Yank'
+        let l:register = (v:register ==? '"' ? g:NERDDefaultRegister : v:register)
         if isVisual
-            execute 'normal! gv"'. v:register . 'y'
+            execute 'normal! gv"'. l:register . 'y'
         elseif countWasGiven
-            execute firstLine .','. lastLine .'yank '. v:register
+            execute firstLine .','. lastLine .'yank '. l:register
         else
-            execute 'normal! "'. v:register .'yy'
+            execute 'normal! "'. l:register .'yy'
         endif
         execute firstLine .','. lastLine .'call nerdcommenter#Comment("'. a:mode .'", "Comment")'
     endif

--- a/plugin/nerdcommenter.vim
+++ b/plugin/nerdcommenter.vim
@@ -43,6 +43,7 @@ call s:InitVariable('g:NERDTrimTrailingWhitespace', 0)
 call s:InitVariable('g:NERDToggleCheckAllLines', 0)
 call s:InitVariable('g:NERDDisableTabsInBlockComm', 0)
 call s:InitVariable('g:NERDSuppressWarnings', 0)
+call s:InitVariable('g:NERDDefaultRegister', '"')
 
 " Section: Comment mapping and menu item setup
 " ===========================================================================


### PR DESCRIPTION
`NERDCommenterYank` (`\cy`) yanks to the default unnamed register `"`. Like all other yanking, this is a good default, this gives the user an option to choose another register.
One use case is creating a “comment and duplicate” function/mapping without clobbering the default register, as discussed in #435.
Closes #543

## Goals
- ✅ `["x][count]\cy` - Support standard register specification for NERDCommenterYank mapping, as with `["x]yy` and friends.
- ❌ `["x]<plug>NERDCommenterYank`, `<plug>NERDCommenterYank({register})`, or similar way to specify a register when invoking this way (e.g. in a user-defined function or mapping).
  - I'm not sure if this is possible. IMO it's not critical because it can be accomplished by remapping to the default maps: `nmap \abc "x\cy`
- ❌ `NERDComment({mode}, {type}, [{register}])` - Specify register when `type=Yank`.
  - I'm very reluctant to mess with the main function signature.
- ✅ `let g:NERDDefaultRegister = x` - Set default register used by NERDCommenterYank.
  - This works. It defaults to `"` (so no behavior change by default) and is overridden when specifying a register with `"x`.

# To do
- [ ] Update documentation